### PR TITLE
separate configs and commands for profiling and prod web builds

### DIFF
--- a/.erb/configs/webpack.web.profiling.babel.js
+++ b/.erb/configs/webpack.web.profiling.babel.js
@@ -110,7 +110,7 @@
      ],
    },
    optimization: {
-     minimize: true,
+     minimize: false,
      minimizer:
        [
          new TerserPlugin({
@@ -141,5 +141,12 @@
          process.env.OPEN_ANALYZER === 'true' ? 'server' : 'disabled',
        openAnalyzer: process.env.OPEN_ANALYZER === 'true',
      }),
-   ]
+   ],
+      resolve: {
+         alias: {
+           'react-dom': 'react-dom/profiling',
+           'scheduler/tracing': 'scheduler/tracing-profiling',
+ //          'schedule/tracking': 'schedule/cjs/schedule-tracking.profiling.min'
+         }
+       }
  });

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build:main": "cross-env NODE_ENV=production webpack --config ./.erb/configs/webpack.config.main.prod.babel.js",
     "build:renderer": "cross-env NODE_ENV=production webpack --config ./.erb/configs/webpack.config.renderer.prod.babel.js",
     "build:web": "cross-env NODE_ENV=production webpack --config ./.erb/configs/webpack.web.prod.babel.js",
+    "build:web:profiling": "cross-env NODE_ENV=production webpack --config ./.erb/configs/webpack.web.profiling.babel.js",
     "rebuild": "electron-rebuild --parallel --types prod,dev,optional --module-dir src",
     "lint": "cross-env NODE_ENV=development eslint . --cache --ext .js,.jsx,.ts,.tsx",
     "package": "rm -rf src/dist && yarn build && electron-builder build --publish never",


### PR DESCRIPTION
This means `npm run build:web` does a production build, and `npm run build:web:profiling` does a build with profiling enabled.