### PR TITLE
fix dropdon, which was being rendered behind dropdown

### DIFF
--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -74,7 +74,6 @@ const LeftSidebar = (props: any) => {
     fontSize: '19px', 
     fontWeight: 600, 
     backgroundColor:'#FAFAFA',
-    zIndex:1000,
     position:'sticky',
     height:'40px',
     top:'0px', 


### PR DESCRIPTION
This fixes the display of a menu, which was rendering *behind* the tag subtitle:

## Current

![zIndex](https://user-images.githubusercontent.com/338833/181937818-a2173ef1-d306-4bf7-962e-77ff7a2abc28.png)


## After this fix
![after-menu](https://user-images.githubusercontent.com/338833/181938486-f218dae1-d764-41c5-8e50-8e08bb87d82b.png)

