### PR TITLE
fix opening of gdoc links from web viewer

### DIFF
--- a/src/fileUtil.ts
+++ b/src/fileUtil.ts
@@ -31,7 +31,7 @@ export const openFile = (fileName: string, folderPath: string) => {
     ipcRenderer.send('open-file', path.join(folderPath, fileName));
   } else {
     const name = fileName.endsWith('.gdoc') ? fileName.slice(0, -5) : fileName;
-    window.open(`${folderPath}${fileName}`, '_blank');
+    window.open(`${folderPath}${name}`, '_blank');
   }
 };
 

--- a/src/fileUtil.ts
+++ b/src/fileUtil.ts
@@ -30,6 +30,7 @@ export const openFile = (fileName: string, folderPath: string) => {
     console.log('Open file:', path.join(folderPath, fileName));
     ipcRenderer.send('open-file', path.join(folderPath, fileName));
   } else {
+    const name = fileName.endsWith('.gdoc') ? fileName.slice(0, -5) : fileName;
     window.open(`${folderPath}${fileName}`, '_blank');
   }
 };


### PR DESCRIPTION
In the right-hand panel of the overview page, some activities have link to `.gdoc` files proxied by the Netlify cloud function (.e.g, "Additional lessons learned" on 31 July 2020 links to `Design Study Lessons Learned.gdoc` ). These are currently broken, and fixed by this PR.

Other activities link directly to Google Docs - e.g., "Email: Planning for the Summer Visit
" links to "test-remove.gdoc" on Google Docs.
