### PR TITLE
Fix "Open file externally" links in reader view

### DIFF
--- a/netlify/functions/download-gdrive-file.js
+++ b/netlify/functions/download-gdrive-file.js
@@ -110,8 +110,13 @@ exports.handler = async function (event) {
       }
     }
 
-    fileData = new Uint8Array(file.data);
-    fileData = Buffer.from(fileData).toString('base64');
+    if (queryStringParameters.raw){
+      fileData = JSON.stringify(file.data)
+    } else {
+      fileData = new Uint8Array(file.data);
+      fileData = Buffer.from(fileData).toString('base64');
+    }
+
   } else if (fileExtension === 'json') {
     file = await drive.files.get({
       alt: 'media',

--- a/netlify/functions/download-gdrive-file.js
+++ b/netlify/functions/download-gdrive-file.js
@@ -67,6 +67,8 @@ exports.handler = async function (event) {
   const filePieces = fileName.split('.');
   const fileExtension = filePieces[filePieces.length - 1];
 
+  let shouldReverseBase64Encoding = false;
+
   if (fileType.includes('application/vnd.google-apps.document')) {
     file = await drive.files.export({
       alt: 'media',
@@ -111,11 +113,10 @@ exports.handler = async function (event) {
     }
 
     if (queryStringParameters.raw){
-      fileData = JSON.stringify(file.data)
-    } else {
-      fileData = new Uint8Array(file.data);
-      fileData = Buffer.from(fileData).toString('base64');
+      shouldReverseBase64Encoding = true;
     }
+    fileData = new Uint8Array(file.data);
+    fileData = Buffer.from(fileData).toString('base64');
 
   } else if (fileExtension === 'json') {
     file = await drive.files.get({
@@ -136,5 +137,6 @@ exports.handler = async function (event) {
   return {
     statusCode: 200,
     body: fileData,
+    isBase64Encoded: shouldReverseBase64Encoding,
   };
 };

--- a/src/components/ReadonlyEntry.tsx
+++ b/src/components/ReadonlyEntry.tsx
@@ -69,20 +69,8 @@ const ReadonlyEntryFile = (props: ReadonlyEntryFilePropTypes) => {
                     `https://docs.google.com/document/d/${file.fileId}/edit?usp=sharing`,
                     '_blank'
                   );
-                } else if (file.fileType === 'pdf') {
-                  let perf = joinPath(folderPath, file.title);
-
-                  readFileSync(perf)
-                    .then((res) => res.text())
-                    .then((pap) => {
-                      console.log('PAP', pap);
-                      window.open(
-                        `data:application/pdf;base64,${pap}`,
-                        '_blank'
-                      );
-                    });
                 } else {
-                  window.open(`${folderPath}${file.title}`, '_blank');
+                  window.open(`${folderPath}${file.title}&raw=1`, '_blank');
                 }
               }
             }}

--- a/src/components/ReadonlyEntry.tsx
+++ b/src/components/ReadonlyEntry.tsx
@@ -288,12 +288,13 @@ const ReadonlyEntry = (props: EntryPropTypes) => {
           <UnorderedList>
             {urls.map((url, i) => (
               <ListItem key={`${url.url}-${i}`}>
-                <a href={url.url}>{url.title}</a>
-                <FaExternalLinkAlt
-                  title="Open URL in default web browser"
-                  size="12px"
-                  style={{ display: 'inline' }}
-                />
+                <a href={url.url}>{url.title}
+                  <FaExternalLinkAlt
+                    title="Open URL in default web browser"
+                    size="12px"
+                    style={{ display: 'inline' }}
+                  />
+                </a>
               </ListItem>
             ))}
           </UnorderedList>


### PR DESCRIPTION
This fixes the "Open file externally" links in the reader views.

To do this, it modifies the `download-gdrive-file` Netlify function, such that  adding `&raw=1` to a `download-gdrive-file` URL causes it to return the raw image, rather than a base64-encoded string representation of it. 

For, example:

* this is a string: https://deploy-preview-106--trrracer.netlify.app/.netlify/functions/download-gdrive-file/?folderName=evobio&fileName=513.png

* this is an image: https://deploy-preview-106--trrracer.netlify.app/.netlify/functions/download-gdrive-file/?folderName=evobio&fileName=513.png&raw=1

