### PR TITLE
don't conditionally use hooks

### DIFF
--- a/src/components/DetailPreview.tsx
+++ b/src/components/DetailPreview.tsx
@@ -72,6 +72,17 @@ const DetailPreview = (props: DetailPreviewPropsType) => {
     dispatch,
   ] = useProjectState();
 
+  //for .gdoc
+  const [chosenGoogData, setchosenGoogData] = useState<null|any>(null);
+  const [chosenComments, setChosenComments] = useState<null|any>(null);
+
+  // for .txt
+  const [textFile, setText] = useState<TextArray>([]);
+
+  // for .pdf
+  const [pageData, setPageData] = useState();
+
+
   const activity = useMemo(() => {
     return projectData.entries.filter(
       (f) => f.activity_uid === selectedArtifact.activity.activity_uid
@@ -130,10 +141,6 @@ const DetailPreview = (props: DetailPreviewPropsType) => {
   }
 
   if (title.endsWith('.gdoc')) {
-
-    const [chosenGoogData, setchosenGoogData] = useState<null|any>(null);
-    const [chosenComments, setChosenComments] = useState<null|any>(null);
-
     useEffect(()=> {
 
       if(isReadOnly){
@@ -234,8 +241,6 @@ const DetailPreview = (props: DetailPreviewPropsType) => {
   }
 
   if (title.endsWith('.txt')) {
-    const [textFile, setText] = useState<TextArray>([]);
-
     const textProcess = (textDat:string, st:any) => {
 
       let textArray =
@@ -364,7 +369,6 @@ const DetailPreview = (props: DetailPreviewPropsType) => {
 
   if (title.endsWith('.pdf')) {
     const perf = joinPath(folderPath, title);
-    const [pageData, setPageData] = useState();
 
     useEffect(() => {
       if (isReadOnly) {


### PR DESCRIPTION
Conditionally using hooks will cause errors. Specifically, this causes a crash when the user switches between viewing different file types (e.g., image and .txt) in the Detail view.

TODO: move the useEffect hooks too