### PR TITLE
replace (broken) eml preview with a placeholder

### DIFF
--- a/src/components/EmailRender.tsx
+++ b/src/components/EmailRender.tsx
@@ -1,51 +1,7 @@
-import React, { useEffect, useState } from 'react';
-import * as Showdown from 'showdown';
-import { readFileSync } from '../fileUtil';
-import { useProjectState } from './ProjectContext';
-
 const EmailRender = (props: any) => {
   const { title } = props;
-  const [{ folderPath }] = useProjectState();
 
-  const [emailData, setEmailData] = useState<null|any>(null);
-
-  useEffect(() => {
-    readFileSync(`${folderPath}/${title}`).then((eml) => {
-      let test = eml.split('Date:').filter((f, i) => i != 0);
-
-      let parsed = test.map((m, i) => {
-        let stringTemp = `Date: ${m}`;
-
-        return stringTemp;
-      });
-
-      setEmailData(parsed);
-    });
-  }, [title]);
-
-  return (
-    // <div
-    // style={{ height: '95%', overflow: 'auto' }}
-    // dangerouslySetInnerHTML={{__html: emailData}}
-    // />
-    emailData ? (
-      <div
-        style={{
-          width: '700px',
-          overflow: 'auto',
-          marginRight: '60px',
-          margin: '10px',
-        }}
-      >
-        {/* <div dangerouslySetInnerHTML={{__html: emailData}} /> */}
-        {emailData.map((em, i) => (
-          <div
-          key={`email-${i}`}
-          >{em}</div>
-        ))}
-      </div>
-    ) : "Email failed to load."
-  );
+  return <div>Emails are not currently previewed in this view.</div>
 };
 
 export default EmailRender;


### PR DESCRIPTION
This has the same visual effect, but avoids generating any errors.