### PR TITLE
fix an artifact/activity index confusion

### DIFF
--- a/src/components/ArtifactDetailWindow.tsx
+++ b/src/components/ArtifactDetailWindow.tsx
@@ -113,7 +113,7 @@ const ArtifactDetailWindow = (props: DetailProps) => {
             onClick={() => {
               const selectActivity =
                 selectedArtifact.activity.index > 0
-                  ? projectData.entries[selectedArtifact.artifactIndex - 1]
+                  ? projectData.entries[selectedArtifact.activity.index - 1]
                   : projectData.entries[projectData.entries.length - 1];
 
               const newHop = [
@@ -153,7 +153,7 @@ const ArtifactDetailWindow = (props: DetailProps) => {
             onClick={() => {
               const selectActivity =
                 selectedArtifact.artifactIndex < projectData.entries.length - 1
-                  ? projectData.entries[selectedArtifact.artifactIndex + 1]
+                  ? projectData.entries[selectedArtifact.activity.index + 1]
                   : projectData.entries[0];
 
               const newHop = [


### PR DESCRIPTION
This bug means the previous/next activity buttons in the detail view don't work: the "previous" button crashes, and the "next" button jumps to the first activity.